### PR TITLE
oracle: Add 12-seconds delay on price feed timestamps

### DIFF
--- a/oracle/src/PriceOracle.py
+++ b/oracle/src/PriceOracle.py
@@ -258,7 +258,7 @@ class PriceOracle:
                 continue
 
             print(f"{pair} price: ${price:.10f}")
-            cur_timestamp = int(time.time())
+            cur_timestamp = int(time.time()) - 12 # TODO: Workaround for https://github.com/oasisprotocol/rofl-paymaster/issues/13
             obs = (int(price * 10**num_decimals), cur_timestamp)
             observations.append(obs)
 


### PR DESCRIPTION
Temporary workaround for https://github.com/oasisprotocol/rofl-paymaster/issues/13.

Adds 6 seconds delay for the block that is about to be processed and another 6 in case of the block not being proposed in time and backup workers spin up.