### PR TITLE
PriceOracle: Add default Mainnet PriceFeedDirectory address

### DIFF
--- a/oracle/oracle/PriceOracle.py
+++ b/oracle/oracle/PriceOracle.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 # Predeployed price directory contract addresses based on the network.
 DEFAULT_PRICE_FEED_ADDRESS: dict[str, str | None] = {
-    "sapphire": None,
+    "sapphire": "0x1e1A7E15dd6eEeD48e00530d31fCf408F40E0A12",
     "sapphire-testnet": "0xB3E8721A5E9bb84Cfa99b50131Ac47341B4a9EfF",
     "sapphire-localnet": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
 }


### PR DESCRIPTION
The default Mainnet PriceFeedDirectory was left out for some reason. Adding it.